### PR TITLE
Update readme.md to reflect file location.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ If you need to change the field in any way, you can easily publish the file to y
 mkdir -p resources/views/vendor/backpack/crud/fields
 
 # copy the blade file inside the folder we created above
-cp -i vendor/digitallyhappy/addon/src/resources/views/fields/toggle.blade.php resources/views/vendor/backpack/crud/fields/toggle.blade.php
+cp -i vendor/digitallyhappy/toggle-field-for-backpack/src/resources/views/fields/toggle.blade.php resources/views/vendor/backpack/crud/fields/toggle.blade.php
 ```
 
 **Step 2.** Remove the vendor namespace wherever you've used the field:


### PR DESCRIPTION
Since the readme was probably old, the path specified in the README (`vendor/digitallyhappy/addon/src/resources/views/fields/toggle.blade.php`) is actually incorrect and the new one is `vendor/digitallyhappy/toggle-field-for-backpack/src/resources/views/fields/toggle.blade.php`;

This PR solves this :)